### PR TITLE
Mirroring message attachments for logging purposes

### DIFF
--- a/commands/config.js
+++ b/commands/config.js
@@ -158,6 +158,7 @@ exports.run = async message => {
                                     await updateConfig(`Level up announcements will now be posted in <#${message.args[3]}>!`, null);
                                     break;
                                 }
+                                throw ['normal', 'You didn\'t mention any channel and/or provided wrong channel ID!'];
                                 break;
                             case 'none':
                                 data.modules.leveling.announcetype = 'none';
@@ -413,6 +414,7 @@ exports.run = async message => {
             +'\n`joinleave` - sets new log channel for join/leave events'
             +'\n`banunban` - sets new log channel for user bans/unbans events'
             +'\n`message` - sets new log channel for message edits/deletions events'
+            +'\n`mediamirror` - sets a channel in which bot will reupload message attachments'
             +'\n`name` - sets new log channel for username/nickname changes'
             // +'\n`avatar` - sets new log channel for avatar updates';
             embed.fields[0].name = 'Currently configured log channels';
@@ -420,6 +422,7 @@ exports.run = async message => {
             +`\nJoin / Leave: ${data.modules.logging.joinleave ? `<#${data.modules.logging.joinleave}> (${data.modules.logging.joinleave})` : ' None'}`
             +`\nBan/Unban: ${data.modules.logging.banunban ? `<#${data.modules.logging.banunban}> (${data.modules.logging.banunban})` : ' None'}`
             +`\nMessage: ${data.modules.logging.message ? `<#${data.modules.logging.message}> (${data.modules.logging.message})` : ' None'}`
+            +`\nMedia Mirror: ${data.modules.logging.mediamirror ? `<#${data.modules.logging.mediamirror}> (${data.modules.logging.mediamirror})` : ' None'}`
             +`\nName: ${data.modules.logging.name ? `<#${data.modules.logging.name}> (${data.modules.logging.name})` : ' None'}`
             // +`\nAvatar: ${data.modules.logging.avatar ? `<#${data.modules.logging.avatar}> (${data.modules.logging.avatar})` : ' None'}`;
             if (message.args[1]) switch(message.args[1].toLowerCase()){
@@ -531,6 +534,39 @@ exports.run = async message => {
                         case 'delete':
                             data.modules.logging.message = null;
                             await updateConfig(`Stopped logging Message events`, null);
+                            break;
+                    }
+                    break;
+                case 'mediamirror':
+                    embed.description = '`set <channelID | #channel>` - sets new Media Mirror channel'
+                    +'\n`clear` - stops reuploading message attachments';
+                    embed.fields[0].name = 'Current setting';
+                    embed.fields[0].value = data.modules.logging.mediamirror ? `<#${data.modules.logging.mediamirror}>` : 'Not configured.';
+                    if (message.args[2]) switch(message.args[2].toLowerCase()){
+                        case 'set':
+                            if (!message.args[3]) throw ['normal', 'Specify media mirror channel (via its ID or #channel)'];
+                            if (message.mentions.channels.size){
+                                //success from mention
+                                if (message.guild.channels.cache.has(message.mentions.channels.firstKey())){
+                                    //channel actually exists in the current server
+                                    data.modules.logging.mediamirror = message.mentions.channels.firstKey();
+                                    await updateConfig(`<#${message.mentions.channels.firstKey()}> is now Media Mirror channel. Message attachments will be reuploaded there`, null);
+                                    break;
+                                }
+                            }
+                            else if (message.guild.channels.cache.filter(ch => ch.type == 'text').get(message.args[3])){
+                                //success from ID
+                                data.modules.logging.mediamirror = message.args[3];
+                                await updateConfig(`<#${message.args[3]}> is now Media Mirror channel. Message attachments will be reuploaded there`, null);
+                                break;
+                            }
+                            throw ['normal', 'You didn\'t mention any channel and/or provided wrong channel ID!'];
+                            break;
+                        case 'clear':
+                        case 'reset':
+                        case 'delete':
+                            data.modules.logging.mediamirror = null;
+                            await updateConfig(`Stopped reuploading message attachments`, null);
                             break;
                     }
                     break;

--- a/events/message.js
+++ b/events/message.js
@@ -38,10 +38,15 @@ module.exports = async message => {
                     setTimeout(function(){ client.cooldowns[cmd.name].delete(`${message.guild ? message.guild.id : message.channel.id}_${message.author.id}`); }, cmd.cooldown);
                 }).catch(async err => { require('../src/utils/errors').command(message, err); });
             }
-            catch (errorino){require('../src/utils/errors').message(message, errorino);}
+            catch (errorino){ require('../src/utils/errors').message(message, errorino); }
         }
         //message handling
-        if (message.channel.type != 'dm') require('../src/modules/leveling')(message);
+        if (message.channel.type != 'dm'){
+            //leveling handler
+            require('../src/modules/leveling')(message);
+            //media mirroring for logging purposes
+            require('../src/modules/mediamirroring')(message);
+        }
     }
     catch (err){
         console.log('Insane message event error!!!!! Stack below:');

--- a/src/modules/logging.js
+++ b/src/modules/logging.js
@@ -220,7 +220,7 @@ exports.nicknameUpdate = async (oldMember, newMember) => {
                 color: 0xa3e0ca,
                 timestamp: new Date(),
                 footer: {
-                    text: newMember.user.tag,
+                    text: `${newMember.user.tag} | ${newMember.user.id}`,
                     icon_url: newMember.user.avatarURL({format:'png', dynamic:true})
                 },
                 author: {

--- a/src/modules/logging.js
+++ b/src/modules/logging.js
@@ -105,9 +105,15 @@ exports.messageDelete = async message => {
                 });
             }
             if (message.attachments ? message.attachments.size : false){
+                let attachmentsString = message.attachments.map(file => `(${formatter.bytesToUnits(file.size)}${file.height ? `, ${file.height}x${file.width}` : ''}) ${file.name}`).join('\n');
+                if (config.modules.logging.mediamirror){
+                    let mirrorData = (await client.db.utils.find('mirroredmedia', {messageid: message.id}))[0];
+                    if (mirrorData) attachmentsString = `[jump to media mirror](${mirrorData.mirrorMessageURL})\n` + attachmentsString;
+                    else attachmentsString = `no media mirror available\n` + attachmentsString;
+                }
                 embed.fields.push({
                     name: 'File Attachments',
-                    value: message.attachments.map(file => `(${formatter.bytesToUnits(file.size)}${file.height ? `, ${file.height}x${file.width}` : ''}) ${file.name}`).join('\n')
+                    value: attachmentsString
                 });
             }
             console.log(`[messageDelete] ${message.id} in #${message.channel.name} (${message.channel.id})`);

--- a/src/modules/logging.js
+++ b/src/modules/logging.js
@@ -110,7 +110,7 @@ exports.messageDelete = async message => {
                     value: message.attachments.map(file => `(${formatter.bytesToUnits(file.size)}${file.height ? `, ${file.height}x${file.width}` : ''}) ${file.name}`).join('\n')
                 });
             }
-            console.log(`[messageDelete] message ${message.id} in #${message.channel.name} (${message.channel.id})`);
+            console.log(`[messageDelete] ${message.id} in #${message.channel.name} (${message.channel.id})`);
             return await logchannel.send({embed:embed});
         }
     }
@@ -133,7 +133,7 @@ exports.messageDeleteBulk = async messages => {
                 },
                 description: messages.map(message => `${message.attachments.size ? `${message.attachments.size} 📎` : ''} [${message.author.tag}]: ${message.content || '*N/A*'}`).join('\n').slice(0, 1023), //slicing, to prevent overflows
             }
-            console.log(`[messageDeleteBulk] ${messages.size} messages deleted in #${logchannel.name} (${logchannel.id})`);
+            console.log(`[messageDeleteBulk] ${messages.size} messages in #${logchannel.name} (${logchannel.id})`);
             return await logchannel.send({embed:embed});
         }
     }

--- a/src/modules/mediamirroring.js
+++ b/src/modules/mediamirroring.js
@@ -1,0 +1,25 @@
+module.exports = async message => {
+    //1. Check if message has attachments
+    //2. Check for guild's config - if there's logging.mediamirror
+    //3. Check if mediamirror channel exists
+    if (!message.attachments.size) return;
+    let mirrorChannelID = client.go[message.guild.id].config.modules.logging.mediamirror;
+    if (!mirrorChannelID) return;
+    let mirrorChannel = message.guild.channels.cache.get(mirrorChannelID);
+    if (!mirrorChannel) return;
+
+    //do stuff
+    //first, fetch link with media and turn it into a buffer
+    const fetch = require('node-fetch');
+    let mirroredMedia = await Promise.all([...message.attachments.keys()].map(async key => {
+        return {
+            buffer: await fetch(message.attachments.get(key).url).then(r => r.buffer()),
+            name: message.attachments.get(key).name
+        }
+    }));
+    let embed = {
+        color: 0x2f3136,
+        description: `Mirrored media of [this](${message.url})\nChannel ID: ${message.channel.id}\nMessage ID: ${message.id}`
+    }
+    let mirrorMessage = await mirrorChannel.send({embed: embed, files: mirroredMedia.map(media => { return {attachment: media.buffer, name: `mirrored_${media.name}`} })});
+}

--- a/src/modules/mediamirroring.js
+++ b/src/modules/mediamirroring.js
@@ -10,16 +10,24 @@ module.exports = async message => {
 
     //do stuff
     //first, fetch link with media and turn it into a buffer
+    //limitting fetches to 25MB max to not overload my very small server
     const fetch = require('node-fetch');
-    let mirroredMedia = await Promise.all([...message.attachments.keys()].map(async key => {
+    let mirroredMedia = await Promise.all([...message.attachments.keys()]
+    .filter(x => message.attachments.get(x).size <= 26214399).map(async key => {
         return {
             buffer: await fetch(message.attachments.get(key).url).then(r => r.buffer()),
             name: message.attachments.get(key).name
         }
     }));
+    if (!mirroredMedia.length) return;
     let embed = {
         color: 0x2f3136,
         description: `Mirrored media of [this](${message.url})\nChannel ID: ${message.channel.id}\nMessage ID: ${message.id}`
     }
     let mirrorMessage = await mirrorChannel.send({embed: embed, files: mirroredMedia.map(media => { return {attachment: media.buffer, name: `mirrored_${media.name}`} })});
+    client.db.utils.insert('mirroredmedia', [{
+        messageid: message.id,
+        // messageURL: message.url, //I think we don't need this, but may be helpful if we wanna make some kind of reverse search
+        mirrorMessageURL: mirrorMessage.url
+    }]);
 }

--- a/src/utils/mongodb.js
+++ b/src/utils/mongodb.js
@@ -111,8 +111,9 @@ mclient.utils.newGuildConfig = async function(theid){
 			logging: {
 				enabled: false,
 				joinleave: null,
-				message: null,
 				banunban: null,
+				message: null,
+				mediamirror: null, //a channel in which all attachments will be reuploaded (already right away after message event)
 				name: null
 			}
 		}


### PR DESCRIPTION
This will introduce an option, in which you can specify a channel in config, where all message attachments will be reuploaded, so they can be linked in a message that is logged on messageDelete (and maybe messageDeleteBulk) event within the same message.

Checklist:
- [x] changeable channel in config
- [x] reuploading media on message event
- [x] documenting message IDs in database
- [x] appending message link to mirrored media on messageDelete event