### PR TITLE
Slight permission rework

### DIFF
--- a/commands/config.js
+++ b/commands/config.js
@@ -674,8 +674,6 @@ exports.run = async message => {
                 }
                 async function permMemberCheck(memberID, boolSet){
                     let member = message.guild.member(memberID);
-                    console.log(message.guild.owner.id, message.author.id);
-                    console.log(message.guild.owner.id != message.author.id);
                     if ((message.guild.owner.id != message.author.id) && (!client.perms.sufficientRole(message.member, member))) {
                         throw [`You need a higher role than this user to ${boolSet ? 'add' : 'remove'} them as server moderator!`]; }
                     if (boolSet){ if (!data.perms.map(p => p.id).includes(memberID)) data.perms.push({

--- a/commands/giveaway.js
+++ b/commands/giveaway.js
@@ -1,9 +1,9 @@
 exports.description = 'Start a new giveaway in specified channel for 20 winners max.'
 +'\nTime should be specified without spaces, like `10m` or `5h30m`.\nSupports y, w, d, h, m, s';
 exports.usage = '<channelID | #channel> <time> <number of winners (must be 1-20)> [giveaway subject]';
-exports.level = 0;
-exports.perms = ['MANAGE_CHANNELS'];
-exports.cooldown = 10000;
+exports.level = 100;
+exports.perms = ['ADMINISTRATOR', 'MANAGE_GUILD'];
+exports.cooldown = 7000;
 exports.dmable = false;
 
 exports.run = async message => {

--- a/commands/help.js
+++ b/commands/help.js
@@ -28,7 +28,7 @@ exports.run = async message => {
         }
         //showing extra commands
         //append guild mod commands
-        let guildModList = client.commands.filter(cmd => (cmd.perms.length && client.perms.guildPerm(cmd.perms, message.channel, message.member)) || (cmd.level >= client.perms.levels.minguildmod && cmd.level <= client.perms.levels.maxguildmod && client.perms.guildLevel(message.member, cmd.level))).map((object, key, map) => `\`${key}\``).join(' | ');
+        let guildModList = client.commands.filter(cmd => (cmd.perms.length && client.perms.guildPerm(cmd.perms, message.channel, message.member)) || (cmd.level >= client.perms.levels.minguildmod && cmd.level <= client.perms.levels.maxguildmod && client.perms.getGuildLevel(message.member, cmd.level))).map((object, key, map) => `\`${key}\``).join(' | ');
         //${cmdUtil.aliases[key]?` aliases:  \`${cmdUtil.aliases[key].join('\`, \`')}\``:''} //alias support for guild-based commands
         if (guildModList.length){
             embed.fields.push({

--- a/commands/roleinfo.js
+++ b/commands/roleinfo.js
@@ -80,6 +80,5 @@ exports.run = async message => {
             inline: false
         });
     }
-    console.log(role);
     message.channel.send(messageOptions);
 }

--- a/events/error.js
+++ b/events/error.js
@@ -1,4 +1,4 @@
 module.exports = info => {
-    console.log(`{error} Client encountered an error:`);
+    console.error(`{error} Client encountered an error:`);
     console.error(info);
 }

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -30,7 +30,6 @@ exports.getUserFromMessage = async function(message, { useQuery, withinGuild } =
     //calling Discord API
     //saving API calls for obvious non-snowflake values
     if (/\d{17,}/.test(message.args[0]) && !withinGuild){
-        console.log(withinGuild);
         const partialUser = await require('./apicalls').getDiscordUser(message.args[0]);
         if (partialUser) return partialUser;
     }

--- a/src/utils/perms.js
+++ b/src/utils/perms.js
@@ -91,11 +91,8 @@ exports.isGod = isGod;
 exports.getUserLvl = getUserLvl;
 exports.isAllowed = (cmd, channel, member) => {
     if (client.cooldowns[cmd.name].has(`${member.guild ? member.guild.id : message.channel.id}_${member.id}`)) return false; //user on cooldown = not allowed
-    console.log('1');
     if (cmd.level >= levels['minguildmod'] && cmd.level <= levels['maxguildmod']) return exports.isGuildAllowed(member, cmd.level); //command.level = 100-200
-    console.log('2');
     if (cmd.perms.length) return exports.guildPerm(cmd.perms, channel, member); //command requires guild permissions
-    console.log('3');
     return Boolean(getUserLvl(member.id) >= cmd.level); //global permission level
 }
 exports.isBanned = (userid) => {
@@ -125,7 +122,7 @@ exports.guildPerm = (gperms, channel, member) => {
     //gods are gods
     if (isGod(member.id)) return true;
     //bot admins
-    if (getUserLvl(member.id) < levels['admin']){
+    if (getUserLvl(member.id) >= levels['admin']){
         let permGrant, ovrGrant;
         gperms.forEach(perm => {
             if (member.permissionsIn(channel).toArray().includes(perm)) permGrant = true;
@@ -135,7 +132,6 @@ exports.guildPerm = (gperms, channel, member) => {
     }
     //guild mods' overrides
     if (exports.isGuildAllowed(member, levels['minguildmod'])){
-        console.log('ayy lmao');
         if (guildModOverrides.some(x => gperms.includes(x))) return true;
     }
     //guild members with right permissions


### PR DESCRIPTION
- Guild Mods should now be able to use some commands that require moderator perms
Note: right now there is hardcoded object (`guildModOverrides`) with permissions which will work globally, later on this will be changeable but that will be implemented once web dashboard will be working.
- `giveaway` command now requires Guild Mod perms (or `ADMINISTRATOR` / `MANAGE_GUILD`.
Both permissions are considered as server admin, because second one can add bots and manage them as well.
- Added new `VIEW_GUILD_INSIGHTS` permission and it's in both `adminOverrides` and `guildModOverrides`.
- Removed debug `console.log`'s in various places